### PR TITLE
Support for m5stack aton with rs485 base

### DIFF
--- a/esphome/boards/board-m5stack-atom.yaml
+++ b/esphome/boards/board-m5stack-atom.yaml
@@ -1,0 +1,51 @@
+###
+## M5 stack atom board powered by usb-c in combination with this base from m5stack:
+## https://shop.m5stack.com/products/atomic-rs485-base
+## NOTE: there are other RS485 boards from m5stack, these are not tested (like the tail-rs485)
+#
+esp32:
+  board: m5stack-atom 
+  framework:
+    type: esp-idf
+
+# uart for modbus rtu
+uart:
+  id: mod_bus
+  baud_rate: 9600
+  stop_bits: 1
+  tx_pin: 19
+  rx_pin: 20
+
+# This board is so tiny there is no ping available on the botom
+#  But with a grove connector you could add GPIO on pin 26 and 32
+# i2c for extra sensor
+#i2c:  
+#  sda: 26
+#  scl: 32
+#  scan: true
+#  id: bus_a
+
+# Enable/Disable logging
+logger:
+  logs:
+    modbus_controller.sensor: WARN
+    modbus_controller.output: WARN
+    modbus.number: WARN
+    esp32.preferences: WARN
+    sensor: WARN
+    text_sensor: WARN
+    dht.sensor: WARN
+    switch: WARN
+    button: WARN
+    number: WARN
+  # baud_rate: 0  # <--- super important! for ESP8266
+
+wifi:
+  ap:
+    ssid: "${name}"
+    password: "configesp"
+captive_portal:
+
+# Enable Web server.
+web_server:
+  port: 80

--- a/esphome/procon.yaml
+++ b/esphome/procon.yaml
@@ -13,18 +13,23 @@ packages:
     url: https://github.com/fonske/Mitsubishi_procon
     ref: main
     files: 
+      # Language Packs:
       - esphome/labels/.procon-labels-en.yaml
       #- esphome/labels/.procon-labels-nl.yaml
+      # Base:
       - esphome/.procon.base.yaml
+      # Boards:
       - esphome/boards/board-esp32.yaml
       #- esphome/boards/board-esp32S3.yaml
+      #- esphome/boards/board-m5stack-atom.yaml
 
 ## for developing/testing, uncomment local includes and comment out remote_package part.
 #packages:
 #  substitutions: !include labels/.procon-labels-nl.yaml
-#  device_base1: !include .procon.base.yaml
-#  device_base2: !include boards/board-esp32.yaml
-#  device_base2: !include boards/board-esp32S3.yaml
+#  device_base1:  !include .procon.base.yaml
+#  device_base2:  !include boards/board-esp32.yaml
+#  device_base2:  !include boards/board-esp32S3.yaml
+#  device_base2:  !include boards/board-m5stack-atom.yaml
 
 wifi:
   ssid: !secret wifi_ssid


### PR DESCRIPTION
Added m5stack atom support with rs485 base: 

https://shop.m5stack.com/products/atomic-rs485-base

Note: 
These:
https://shop.m5stack.com/products/rs485-module
https://shop.m5stack.com/products/atom-tail485
https://shop.m5stack.com/products/isolated-rs485-unit

are not tested, but might work by simply changing the uart settings.