### PR TITLE
Dualzones

### DIFF
--- a/esphome/.procon.base.yaml
+++ b/esphome/.procon.base.yaml
@@ -49,6 +49,7 @@ sensor:
     register_type: read
     value_type: U_WORD
     accuracy_decimals: 0
+    state_class: "measurement"
 
     ## Temperature Setpoint – Zone 1 (signed) (FC4: 40, MA: 30041)
   - platform: modbus_controller
@@ -62,6 +63,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.01
 
@@ -77,6 +79,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.01
 
@@ -92,6 +95,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.01
 
@@ -107,6 +111,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.1
 
@@ -122,6 +127,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.01
 
@@ -137,6 +143,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.01
     
@@ -152,6 +159,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.1
 
@@ -167,6 +175,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.01
 
@@ -182,6 +191,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.01
 
@@ -197,6 +207,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.01
 
@@ -212,6 +223,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.01
 
@@ -227,6 +239,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.01
 
@@ -242,6 +255,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
     filters:
       - multiply: 0.01
 
@@ -528,6 +542,7 @@ sensor:
     register_type: read
     value_type: U_WORD
     accuracy_decimals: 1
+    state_class: "measurement"
 
     ## Version of main software (FC4: 199, MA: 30200)
 #  - platform: modbus_controller

--- a/esphome/.procon.zone2.yaml
+++ b/esphome/.procon.zone2.yaml
@@ -1,0 +1,136 @@
+sensor:
+    ## Temperature Setpoint – Zone 2 (signed) (FC4: 42, MA: 30043)
+  - platform: modbus_controller
+    modbus_controller_id: ${name}
+    id: temperature_setpoint_zone_2
+    name: ${device} Temperature Setpoint – Zone 2
+    icon: mdi:home-thermometer
+    address: 0x2A
+    device_class: temperature
+    unit_of_measurement: "°C"
+    register_type: read
+    value_type: S_WORD
+    accuracy_decimals: 1
+    state_class: "measurement"
+    filters:
+      - multiply: 0.01
+    ## Flow Temperature Setpoint – Zone 2 (signed) (FC4: 46, MA: 30047)
+  - platform: modbus_controller
+    modbus_controller_id: ${name}
+    id: flow_temperature_setpoint_zone_2
+    name: ${device} Flow Temperature Setpoint – Zone 2
+    icon: mdi:thermometer-auto
+    address: 0x2E
+    device_class: temperature
+    unit_of_measurement: "°C"
+    register_type: read
+    value_type: S_WORD
+    accuracy_decimals: 1
+    state_class: "measurement"
+    filters:
+      - multiply: 0.01
+    ## Room Temperature – Zone 2 (signed) (FC4: 54, MA: 30054)
+  - platform: modbus_controller
+    modbus_controller_id: ${name}
+    id: room_temperature_zone_2
+    name: ${device} Room temperature - Zone 2
+    icon: mdi:home-thermometer
+    address: 0x36
+    device_class: temperature
+    unit_of_measurement: "°C"
+    register_type: read
+    value_type: S_WORD
+    accuracy_decimals: 1
+    state_class: "measurement"
+    filters:
+      - multiply: 0.01
+    ## Flow Temperature – Zone 2 (signed) (FC4: 70, MA: 30071)
+  - platform: modbus_controller
+    modbus_controller_id: ${name}
+    id: flow_temperature_zone_2
+    name: ${device} Flow temperature - Zone 2
+    icon: mdi:thermometer-auto
+    address: 0x46
+    device_class: temperature
+    unit_of_measurement: "°C"
+    register_type: read
+    value_type: S_WORD
+    accuracy_decimals: 1
+    state_class: "measurement"  
+    filters:
+      - multiply: 0.01
+    ## Return Temperature – Zone 2 (signed) (FC4: 72, MA 30073)
+  - platform: modbus_controller
+    modbus_controller_id: ${name}
+    id: return_temperature_zone_2
+    name: ${device} Return temperature - Zone 2
+    icon: mdi:thermometer
+    address: 0x48
+    device_class: temperature
+    unit_of_measurement: "°C"
+    register_type: read
+    value_type: S_WORD
+    accuracy_decimals: 1
+    state_class: "measurement"  
+    filters:
+      - multiply: 0.01
+
+number:
+    ## H/C Thermostat Target Temperature – Zone 2 (signed) (FC6: 34, MA: 40035)
+  - platform: modbus_controller
+    modbus_controller_id: ${name}
+    id: hc_thermostat_target_temperature_zone_2
+    name: ${device} H/C Thermostat Target Temperature – Zone 2
+    device_class: temperature
+    icon: mdi:home-thermometer
+    address: 0x22
+    unit_of_measurement: "°C"
+    step: 0.5
+    register_type: holding
+    value_type: S_WORD
+    min_value: 10
+    max_value: 36
+    multiply: 100
+    ## Thermostat Target Temperature – Zone 2 (signed) (FC6: 56, MA: 40057)
+  - platform: modbus_controller
+    modbus_controller_id: ${name}
+    id: thermostat_target_temperature_zone_2
+    name: ${device} Thermostat Target Temperature – Zone 2
+    device_class: temperature
+    icon: mdi:home-thermometer
+    address: 0x38
+    unit_of_measurement: "°C"
+    step: 0.5
+    register_type: holding
+    value_type: S_WORD
+    min_value: 10
+    max_value: 36
+    multiply: 100
+
+switch:
+    ## Cooling On Prohibit – Zone 2 (FC6: 43, MA: 40044)
+  - platform: modbus_controller
+    modbus_controller_id: ${name}
+    id: cooling_on_prohibit_zone_2
+    name: ${device} Cooling On Prohibit – Zone 2
+    register_type: holding
+    icon: mdi:block-helper
+    address: 0x2B
+    bitmask: 1
+    entity_category: config
+
+select:
+    ## A/C mode – Zone 2 (FC6: 29, 40030)
+  - platform: modbus_controller
+    modbus_controller_id: ${name}
+    id: ac_mode_zone_2
+    name: ${device} A/C mode - Zone 2
+    address: 0x1D
+    optionsmap:
+      "Heating room": 0
+      "Heating flow": 1
+      "Heating curve": 2
+      "Cooling room": 3
+      "Cooling flow": 4
+      "Floor Dryup": 5
+    entity_category: config

--- a/esphome/boards/board-m5stack-atom.yaml
+++ b/esphome/boards/board-m5stack-atom.yaml
@@ -14,7 +14,7 @@ uart:
   baud_rate: 9600
   stop_bits: 1
   tx_pin: 19
-  rx_pin: 20
+  rx_pin: 22
 
 # This board is so tiny there is no ping available on the botom
 #  But with a grove connector you could add GPIO on pin 26 and 32

--- a/esphome/procon.yaml
+++ b/esphome/procon.yaml
@@ -22,6 +22,9 @@ packages:
       - esphome/boards/board-esp32.yaml
       #- esphome/boards/board-esp32S3.yaml
       #- esphome/boards/board-m5stack-atom.yaml
+      ###
+      ## Zone 2, If you have 2 zones on the heatpump enable this:
+      #- esphome/.procon.zone2.yaml
 
 ## for developing/testing, uncomment local includes and comment out remote_package part.
 #packages:
@@ -34,6 +37,11 @@ packages:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  # Enable fast wifi connection:
+  #fast_connect: on
+  # Enable static IP:
+  #use_adress: # Example: 192.168.1.1
+  
   # uncomment when it needs to run on a .local domain
   #  domain: .local
 


### PR DESCRIPTION
Added dual zones as a import, this way it is default 1 zone importable to 2.

added `state_class: "measurement"` so that HA will be able to add it into statistic cards.