### PR TITLE
enable ota_password

### DIFF
--- a/esphome/.procon.base.yaml
+++ b/esphome/.procon.base.yaml
@@ -10,7 +10,7 @@ api:
   reboot_timeout: 0s
 
 ota:
-#  password: !secret ota_password
+  password: !secret ota_password
 
 ### modbus ###
 modbus:


### PR DESCRIPTION
In the secret you mentioned the ota_password but it isn't enabled in the actual procon base file