### PR TITLE
update comment

### DIFF
--- a/esphome/procon.yaml
+++ b/esphome/procon.yaml
@@ -42,7 +42,7 @@ wifi:
   # Enable static IP:
   #use_adress: # Example: 192.168.1.1
   
-  # uncomment when it needs to run on a .local domain
+  # uncomment and change when it needs to run on a non .local domain
   #  domain: .local
 
 # Put your API key here if you have one


### PR DESCRIPTION
small update on the comment about the local domain name. The default is .local when not specified.
I'm using domain: .home on my network so that it becomes available on mitsubishi.home instead of mitsubishi.local

Main reason is that the .local is a reserved domain and not all devices broadcast their name on this domain over your network. I updated my dhcp server to use the .home as the searchdomain so that all devices can be reached using that.
