### PR TITLE
Set heat_pump_run_time unit_of_measurement to 'h'

### DIFF
--- a/esphome/.procon.base.yaml
+++ b/esphome/.procon.base.yaml
@@ -304,7 +304,7 @@ sensor:
     name: "${name} ${heat_pump_run_time}"
     icon: mdi:wrench-clock
     device_class: duration
-    unit_of_measurement: "hrs"
+    unit_of_measurement: "h"
     accuracy_decimals: 0
     lambda: |-
       return id(heat_pump_run_time_100).state + id(heat_pump_run_time_1).state;


### PR DESCRIPTION
Fixes a warning in the Home Assistant logs. 'hrs' is not a valid unit for this device class, but 'h' is.
See also https://developers.home-assistant.io/docs/core/entity/sensor?_highlight=device&_highlight=class#available-device-classes